### PR TITLE
Add notification medium for web deface

### DIFF
--- a/web_deface/monitor.py
+++ b/web_deface/monitor.py
@@ -8,7 +8,11 @@ import sys
 class Monitor(object):
     """Class for Monitor."""
 
-    def __init__(self):
+    def __init__(self,
+                 twitter=None,
+                 telegram=None,
+                 slack=None,
+                 twilio_sms=None):
         """Intialize Monitor class."""
 
         self.JSON_PATH = 'hash.json'
@@ -22,6 +26,42 @@ class Monitor(object):
         # Initialize change_dict
         for key in self.hash_dict.keys():
             self.change_dict[key] = 0
+
+        # Intialize notification medium
+        self.twitter_obj = twitter
+        self.slack_obj = slack
+        self.telegram_obj = telegram
+        self.twilio_sms_obj = twilio_sms
+
+    def notify(self, msg):
+        """
+        Send the warning message using the
+        notification medium.
+
+        Args:
+            msg: (str) Message to send
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Send a warning message using twitter
+        if self.twitter_obj is not None:
+            self.twitter_obj.notify(msg)
+
+        # Send a warning message using slack
+        if self.slack_obj is not None:
+            self.slack_obj.notify(msg)
+
+        # Send a warning message using twilio sms
+        if self.twilio_sms_obj is not None:
+            self.twilio_sms_obj.notify(msg)
+
+        # Send a warning message using telegram
+        if self.telegram_obj is not None:
+            self.telegram_obj.notify(msg)
 
     def read_file(self):
         """
@@ -85,8 +125,10 @@ class Monitor(object):
                 self.change_dict[url] = self.change_dict[url] + 1
                 if (self.change_dict[url] > self._TOLERANCE):
                     self.change_dict[url] = 0
-                    msg = "[!] Change detected in: {}".format(url)
-                    print(msg)
+                    msg = "Change detected in: {}, (WARNING)".format(url)
+                    # Notify
+                    self.notify(msg)
+                    print("[!] ", msg)
 
     def monitor(self):
         """

--- a/web_deface/notifs/arguments.py
+++ b/web_deface/notifs/arguments.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+import argparse
+
+
+def get_args():
+    """Docstring.
+
+    Returns:
+        Args: total arguments
+    """
+    parser = argparse.ArgumentParser(description='Risk Assessment Framework')
+
+    parser.add_argument(
+        '--twitter_api_key',
+        '-tak',
+        type=str,
+        required=False,
+        help='Twitter api key'
+    )
+
+    parser.add_argument(
+        '--twitter_api_secret_key',
+        '-tas',
+        type=str,
+        required=False,
+        help='Twitter api secret'
+    )
+
+    parser.add_argument(
+        '--twitter_access_token',
+        '-tat',
+        type=str,
+        required=False,
+        help='Twitter access token'
+    )
+
+    parser.add_argument(
+        '--twitter_access_token_secret',
+        '-tats',
+        type=str,
+        required=False,
+        help='Twitter access token secret'
+    )
+
+    parser.add_argument(
+        '--telegram_bot_token',
+        '-tbt',
+        type=str,
+        required=False,
+        help='Telegram Bot Token'
+    )
+
+    parser.add_argument(
+        '--telegram_user_id',
+        '-tui',
+        type=str,
+        required=False,
+        help='Telegram user id'
+    )
+
+    parser.add_argument(
+        '--twilio_sid',
+        '-tws',
+        type=str,
+        required=False,
+        help='Twilio SID'
+    )
+
+    parser.add_argument(
+        '--twilio_token',
+        '-twt',
+        type=str,
+        required=False,
+        help='Twilio authorization token'
+    )
+
+    parser.add_argument(
+        '--twilio_from',
+        '-twf',
+        type=str,
+        required=False,
+        help='Twilio (From) phone number'
+    )
+
+    parser.add_argument(
+        '--twilio_to',
+        '-twto',
+        type=str,
+        required=False,
+        help='Twilio (To) phone number'
+    )
+
+    parser.add_argument(
+        '--slack_token',
+        '-st',
+        type=str,
+        required=False,
+        help='Slack token'
+    )
+
+    parser.add_argument(
+        '--slack_user_id',
+        '-suid',
+        type=str,
+        required=False,
+        help='Slack user id'
+    )
+
+    args = parser.parse_args()
+    return args

--- a/web_deface/notifs/slack.py
+++ b/web_deface/notifs/slack.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+u"""Slack Notifier module.
+
+    Author: Mishal Shah <shahmishal1998@gmail.com> , Jan 29 2019
+    Version: 1.1
+
+"""
+import requests
+
+
+class Slack():
+    """Initilize the slack."""
+
+    def __init__(self, cred):
+        """Init logger params.
+
+        Args:
+            modulename (str): Script module name
+            cred (dict): Slack user_id, token
+        """
+        self.slack_token = cred['token']
+        self.user_id = cred['user_id']
+        self.slack_channel_open_url = 'https://slack.com/api/im.open'
+        self.slack_post_message_url = 'https://slack.com/api/chat.postMessage'
+        self.auth_header = 'Bearer ' + self.slack_token
+
+    def notify(self, msg):
+        """Docstring.
+
+        Args:
+            msg (TYPE): Description
+        """
+        message = (str(msg))
+
+        channel_info = requests.post(
+            self.slack_channel_open_url,
+            headers={"Authorization": self.auth_header},
+            data={"user": self.user_id}
+        ).json()
+        channel_id = channel_info['channel']['id']
+
+        post_message = requests.post(
+            self.slack_post_message_url,
+            headers={"Authorization": self.auth_header},
+            data={"channel": channel_id, "text": message}
+        ).json()
+
+        if post_message['ok'] is True:
+            print("[+] Slack notification sent")
+        else:
+            print("[!] Slack notification not sent, error is: " +
+                  str(post_message['error']))
+        return

--- a/web_deface/notifs/telegram.py
+++ b/web_deface/notifs/telegram.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+u"""Telegram Notifier.
+
+    Author: Mishal Shah <shahmishal1998@gmail.com> , Jan 26 2019
+    Version: 1.1
+
+"""
+import telegram
+
+
+class Telegram():
+    """Initilize the telegram."""
+
+    def __init__(self, cred):
+        """Init logger params.
+
+        Args:
+            modulename (str): Script module name
+            cred (dict): Telegram user_id
+        """
+        self.token = cred['token']
+        self.user_id = cred['user_id']
+
+    def notify(self, msg):
+        """Docstring.
+
+        Args:
+            msg (TYPE): Description
+        """
+        message = (str(msg) + " at " + common.getdatetime() +
+                   " " + common.get_current_location() + common.get_platform())
+
+        bot = telegram.Bot(token=self.token)
+        bot.send_message(chat_id=self.user_id, text=message)
+        print("[+] Telegram notification sent.")
+        return

--- a/web_deface/notifs/twilio_sms.py
+++ b/web_deface/notifs/twilio_sms.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+u"""Twilio module.
+
+    Author: Abhishek Sharma <abhishek_official@hotmail.com> , Jan 26 2019
+    Version: 1.1
+
+"""
+from twilio.rest import Client
+
+
+class Twilio():
+    """Initilize the Twilio."""
+
+    def __init__(self, cred):
+        """Init logger params.
+
+        Args:
+        -----
+            modulename (str): Twilio
+            cred (dict): Twilio credentials
+        """
+        self.account_sid = cred['twilio_sid']
+        self.account_token = cred['twilio_token']
+        self.twilio_from = cred['twilio_from']
+        self.twilio_to = cred['twilio_to']
+
+        self.client = Client(self.account_sid, self.account_token)
+
+    @staticmethod
+    def generatemessage(msg):
+        """
+        Generate message by attaching the current CPU time.
+
+        Args:
+        -----
+        :msg : str
+            Message to send
+
+        Returns:
+        --------
+        str: Message appended with CPU time
+        """
+        message = (str(msg))
+
+        return message
+
+    def notify(self, msg):
+        """
+        Send the generated message.
+
+        Args:
+        -----
+        :msg : str
+            Message to send
+
+        Returns:
+        --------
+        None
+        """
+        try:
+            self.client.messages \
+                .create(
+                    body=self.generatemessage(msg),
+                    from_=self.twilio_from,
+                    to=self.twilio_to
+                )
+
+        except Exception as e:
+            print("[!] Error in sending SMS: ", str(e))
+            return
+        print("[+] SMS notification sent.")
+        return

--- a/web_deface/notifs/twitter.py
+++ b/web_deface/notifs/twitter.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+u"""Twitter module.
+
+    Author: Rejah Rehim <rejah@appfabs.com> , Aug 30 2018
+    Version: 1.1
+
+"""
+import json
+import requests
+from requests_oauthlib import OAuth1
+
+
+class Twitter():
+    """Initilize the twitter."""
+
+    def __init__(self, cred):
+        """Init logger params.
+
+        Args:
+            modulename (str): Script module name
+            cred (dict): Twitter credentials
+            username (TYPE): Twitter username to post the message
+        """
+        self.baseUrl = "https://api.twitter.com/1.1"
+        self.auth = OAuth1(cred['api_key'], cred['api_secret_key'], cred[
+                           'access_token'], cred['access_token_secret'])
+
+        self.id = self.getuserid()
+
+    def getuserid(self):
+        """Docstring."""
+        endpoint = "/account/verify_credentials.json"
+        response = requests.get(self.baseUrl + endpoint, auth=self.auth)
+        response = response.json()
+        return response['id']
+
+    def notify(self, msg):
+        """Docstring.
+
+        Args:
+            msg (TYPE): Description
+        """
+        try:
+            message = (str(msg))
+            data = {
+                "event": {
+                    "type": "message_create",
+                    "message_create": {
+                        "target": {
+                            "recipient_id": self.id
+                        },
+                        "message_data": {
+                            "text": message
+                        }
+                    }
+                }
+            }
+
+            endpoint = "/direct_messages/events/new.json"
+            response = requests.post(
+                self.baseUrl + endpoint,
+                auth=self.auth,
+                data=json.dumps(data)
+            )
+            if response.status_code == 200:
+                print("[+] Twitter notification sent")
+            else:
+                print("[!] Twitter notification not sent, error is: " +
+                      str(response.text))
+            return
+        except Exception as e:
+            print("[!] Exception in Twitter notification sent, error is: " +
+                  str(e))
+        return

--- a/web_deface/requirements.txt
+++ b/web_deface/requirements.txt
@@ -1,0 +1,5 @@
+requests
+requests_oauthlib
+python-telegram-bot
+twilio
+tqdm

--- a/web_deface/web_deface.py
+++ b/web_deface/web_deface.py
@@ -4,12 +4,17 @@ from cache import Cache
 import deface_utils
 from crawler import Crawler
 import platform
+from notifs import arguments
+from notifs import slack
+from notifs import twitter
+from notifs import telegram
+from notifs import twilio_sms
 
 
 class WebDeface(object):
     """Class for WebDeface."""
 
-    def __init__(self):
+    def __init__(self, args):
         """Intialize WebDeface."""
 
         if int(platform.sys.version_info[0]) < 3:  # if Python 2.X.X
@@ -30,8 +35,64 @@ class WebDeface(object):
         self.cache_obj = Cache()
         self.cache_obj.generate_cache()
 
-        # Create a monitor object
-        self.monitor_obj = Monitor()
+        # Arguments
+        self.args = args
+
+        # Initialize empty objects
+        self.twitter_obj = None
+        self.slack_obj = None
+        self.telegram_obj = None
+        self.twilio_sms_obj = None
+
+    def create_notifier_objs(self):
+        """
+        Create notification medium objects.
+
+        Args:
+            None
+
+        Raises:
+            None
+
+        Returns:
+            None
+        """
+        # Parse all the arguments
+        if (self.args.twitter_api_key and
+            self.args.twitter_access_token and
+            self.args.twitter_api_secret_key and
+            self.args.twitter_access_token_secret):
+            cred = {}
+            cred["api_key"] = self.args.twitter_api_key
+            cred["access_token"] = self.args.twitter_access_token
+            cred["api_secret_key"] = self.args.twitter_api_secret_key
+            cred["access_token_secret"] = self.args.twitter_access_token_secret
+            self.twitter_obj = twitter.Twitter(cred)
+
+        if (self.args.twilio_to and
+            self.args.twilio_from and
+            self.args.twilio_token and
+            self.args.twilio_sid):
+            cred = {}
+            cred["twilio_to"] = self.args.twilio_to
+            cred["twilio_sid"] = self.args.twilio_sid
+            cred["twilio_token"] = self.args.twilio_token
+            cred["twilio_from"] = self.args.twilio_from
+            self.twilio_sms_obj = twilio_sms.Twilio(cred)
+
+        if (self.args.slack_token and
+            self.args.slack_user_id):
+            cred = {}
+            cred["token"] = self.args.slack_token
+            cred["user_id"] = self.args.slack_user_id
+            self.slack_obj = slack.Slack(cred)
+
+        if (self.args.telegram_user_id and
+            self.args.telegram_bot_token):
+            cred = {}
+            cred["user_id"] = self.args.telegram_user_id
+            cred["token"] = self.args.telegram_bot_token
+            self.telegram_obj = telegram.Telegram(cred)
 
     def start(self):
         """
@@ -47,11 +108,21 @@ class WebDeface(object):
             None
         """
         print("[!] Remote Web Deface Detection started")
+        # Create a monitor object
+        self.monitor_obj = Monitor(twitter=self.twitter_obj,
+                                   slack=self.slack_obj,
+                                   twilio_sms=self.twilio_sms_obj,
+                                   telegram=self.telegram_obj)
         # Start the monitor loop
         self.monitor_obj.monitor()
 
 
 if __name__ == '__main__':
 
-    web_deface_obj = WebDeface()
+    # Fetch all the arguments
+    args = arguments.get_args()
+
+    # Create a web deface object
+    web_deface_obj = WebDeface(args)
+    web_deface_obj.create_notifier_objs()
     web_deface_obj.start()


### PR DESCRIPTION
@adeyosemanputra As per discussion, I'm sending the PR connecting web deface with the following notification medium.
1. Twitter
2. Telegram
3. Slack
4. SMS

As discussed earlier, I have used the respective source code, and their original authors have been respectfully mentioned. I have edited it to fit the current environment.

Here's a short summary:

**Changes**
- Connected web deface with the above notification mediums.
- `requirements.txt` is added for easy installation

**Checklist**
- [x] Python 2 & 3 compatible
- [x] Well tested locally
- [x] Documentation & doc-string whenever & wherever required

**Steps to start**
1. `cd web_deface/`
2. `pip install -r requirements.txt`
3. `python web_deface.py <notif arguments>`
For notif arguments, please have a look at `notifs/arguments.py`

**Development Environment**
```
Operating System: Ubuntu 18.04 LTS
Python: 3.6.6 & 2.7
```
**Running**
For **testing only** I have stimulated the code a bit to be sensitive to changes.
![raf](https://user-images.githubusercontent.com/29058921/55748053-4c4ab900-5a5b-11e9-8738-fdbbed8ad4f5.gif)