### PR TITLE
Fix typo in broken authentication

### DIFF
--- a/gui/src/app/view/resources/resources.component.ts
+++ b/gui/src/app/view/resources/resources.component.ts
@@ -1480,7 +1480,7 @@ export class ResourcesComponent implements OnInit {
   password processes, such as "knowledge based answers",
   which cannot be made safe.
   •
-  Uses plain text, encrypted, or weakly hashed passwords (see
+  Uses plain text, unencrypted, or weakly hashed passwords (see
   A3:2017 Sensitive Data Exposure
   •
   Has missing or ineffective multi factor authentication.


### PR DESCRIPTION
Noticed a pretty confusing typo when reading the 2017 spec for Broken Authentication, assuming I haven't dramatically misunderstood its intention!

Also have PRs for the same issue in [www-project-top-ten](https://github.com/OWASP/www-project-top-ten/pull/24) and [Top10](https://github.com/OWASP/Top10/pull/507).